### PR TITLE
Js partial functions - operator cleanup

### DIFF
--- a/Swift47Deg/Swift47Deg/Functions/PartialFunction.swift
+++ b/Swift47Deg/Swift47Deg/Functions/PartialFunction.swift
@@ -21,7 +21,7 @@ import Swiftz
 
 infix operator |||> { associativity left precedence 140 }
 infix operator |-> { associativity left precedence 140 }
-prefix operator => {}
+prefix operator ∫ {}
 
 // MARK: - Partial function container
 
@@ -72,15 +72,20 @@ func |||> <T, U>(a: PartialFunction<T, U>, b: PartialFunction<T, U>) -> Function
 /**
 Defines a function whose execution is restricted to a certain set of values defined by the left function. i.e. to define a partial function to multiply all even values by two:
 
-Function.arr({ $0 % 2 == 0 }) |-> Function.arr({ $0 * 2 })
+Function({ $0 % 2 == 0 }) |-> Function({ $0 * 2 })
 */
 func |-><T, U>(isDefinedAt: Function<T, Bool>, function: Function<T, U>) -> PartialFunction<T, U> {
     return PartialFunction<T, U>(function: function, isDefinedAt: isDefinedAt)
 }
 
+func |-><T, U>(isDefinedAt: T -> Bool, function: T -> U) -> PartialFunction<T, U> {
+    return PartialFunction<T, U>(function: Function(function), isDefinedAt: Function(isDefinedAt))
+}
+
 /**
-Syntatic sugar, equivalent to Function.arr(T -> U)
+Syntatic sugar, equivalent to Function.arr(T -> U).
+Key shortcut: ⌥+S (Unicode 0x222B).
 */
-prefix func =><T, U>(f: T -> U) -> Function<T, U> {
-    return Function.arr(f)
+prefix func ∫ <T, U>(f: T -> U) -> Function<T, U> {
+    return Function(f)
 }

--- a/Swift47Deg/Swift47DegTests/Functions/PartialFunctionTests.swift
+++ b/Swift47Deg/Swift47DegTests/Functions/PartialFunctionTests.swift
@@ -31,9 +31,9 @@ class PartialFunctionTests: XCTestCase {
     }
     
     func testPartialFunctions() {
-        let doubleEvens = =>{ $0 % 2 == 0 } |-> =>{ $0 * 2 }
-        let tripleOdds = =>{ $0 % 2 != 0 } |-> =>({ $0 * 3 })
-        let addFive = =>(+5)
+        let doubleEvens = { $0 % 2 == 0 } |-> { $0 * 2 }
+        let tripleOdds = { $0 % 2 != 0 } |-> { $0 * 3 }
+        let addFive = ∫(+5)
         
         let opOrElseOp = doubleEvens |||> tripleOdds
         let opOrElseAndThenOp = doubleEvens |||> tripleOdds >>> addFive
@@ -44,8 +44,8 @@ class PartialFunctionTests: XCTestCase {
         XCTAssertEqual(opOrElseAndThenOp.apply(3), 14, "Partial functions should be attachable with orElse and andThen conditionals")
         XCTAssertEqual(opOrElseAndThenOp.apply(4), 13, "Partial functions should be attachable with orElse and andThen conditionals")
         
-        let printEven = =>({ (value : Int) -> Bool in value % 2 == 0}) |-> =>({ (Int) -> String in return "Even"})
-        let printOdd = =>({ (value : Int) -> Bool in value % 2 != 0}) |-> =>({ (Int) -> String in return "Odd"})
+        let printEven = { (value : Int) -> Bool in value % 2 == 0} |-> { (Int) -> String in return "Even"}
+        let printOdd = { (value : Int) -> Bool in value % 2 != 0} |-> { (Int) -> String in return "Odd"}
         
         let complexOp = doubleEvens |||> tripleOdds >>> (printEven |||> printOdd)
         XCTAssertEqual(complexOp.apply(3), "Odd", "Partial functions should be attachable with orElse and andThen conditionals")
@@ -55,7 +55,7 @@ class PartialFunctionTests: XCTestCase {
     func testCollect() {
         let map : Map<Double> = ["a" : -1, "b" : 0, "c" : 1, "d" : 2, "e" : 3, "f" : 4]
         // Sometimes type inference won't work while creating arrows with complex types using the => operator, so we need to be explicit:
-        let squareRoot = =>({ $0.1 >= 0 }) |-> Function<(HashableAny, Double), (HashableAny, Double)>.arr({ ($0.0, sqrt(Double($0.1))) })
+        let squareRoot = ∫({ $0.1 >= 0 }) |-> Function<(HashableAny, Double), (HashableAny, Double)>.arr({ ($0.0, sqrt(Double($0.1))) })
         let collectResult = map.collect(squareRoot)
         
         XCTAssertNil(collectResult["a"], "Collect function should obbey to its partial function's restrictions")


### PR DESCRIPTION
This PR includes some improvements (I think) to the syntax for creating partial functions in our library. Those are:
- Partial functions are now created using the |-> operator (equivalent to the partial function math operator - http://en.wikipedia.org/wiki/Partial_function). This operator now supports both Swiftz's Functions (arrows were not needed for this) and also normal Swift's closures (by wrapping them in a function by itself). So now we're able to build expressions like: let doubleEvens = { $0 % 2 == 0 } |-> { $0 \* 2 }
- Added a syntactic sugar operator to define Swiftz Functions with the character ∫. It is supposed to mean "ƒ", but Swift only allows one certain subset of unicode characters (only math symbols, even if ƒ is...).
- Removed "andThen" function and operator, as Swiftz supported >>> operator on its own.
- "orElse" is performed with the |||> operator. "|||" is used in Swiftz for fan-in arrows, and I couldn't overload the operator as it created conflicts. So you can have:

let opOrElseAndThenOp = doubleEvens |||> tripleOdds >>> addFive

What do you think, @anamariamv and @raulraja, do they look OK for you? Thanks!!
