### PR TITLE
Fixing link to Swiftz library

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,7 @@
                 <div class="row">
                     <div class="col-md-5">
                         <h3>Functional Programming in Swift</h3>
-                        <p>Functional Programming has a lot of key benefits that can improve your development process by avoiding side effects and providing referential transparency. Your code will be cleaner, safer, and easier to test. Our intention by creating this framework is to extend a great functional framework (Swiftz
-                            <- this should be a link) while bringing a lot of the syntax and features of the Scala language. We’re enjoying the benefits of Scala in our projects here in 47 Degrees for a while, and we’d love Second Bridge to be your gateway to Functional Programming in your iOS apps!</p>
+                        <p>Functional Programming has a lot of key benefits that can improve your development process by avoiding side effects and providing referential transparency. Your code will be cleaner, safer, and easier to test. Our intention by creating this framework is to extend a great functional framework like <a href="https://github.com/typelift/Swiftz">Swiftz</a>, while bringing a lot of the syntax and features of the Scala language. We’re enjoying the benefits of Scala in our projects here in 47 Degrees for a while, and we’d love Second Bridge to be your gateway to Functional Programming in your iOS apps!</p>
                     </div>
                     <div class="col-md-7">
                         <img class="img-responsive" src="img/image_functional_programming.png" alt="">


### PR DESCRIPTION
This PR fixes a placeholder that should point to the Swiftz library GitHub repo. Could you please review, @rafaparadela ? Thanks!! :)
