### PR TITLE
Updated podspec/Podfile to tag the current version

### DIFF
--- a/SecondBridge.podspec
+++ b/SecondBridge.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.source   = { :git => "https://github.com/47deg/second-bridge.git", :tag => "v#{s.version}"}
   s.source_files = "SecondBridge/SecondBridge/**/*.swift"
-  s.dependency 'Swiftz'
+  s.dependency 'Swiftz', '0.2.2'
 end

--- a/SecondBridge/Podfile
+++ b/SecondBridge/Podfile
@@ -2,4 +2,4 @@ platform :ios, '8.0'
 inhibit_all_warnings!
 use_frameworks!
 link_with 'SecondBridge','SecondBridgeTests', 'VectorTests'
-pod 'Swiftz'
+pod 'Swiftz', '0.2.2'


### PR DESCRIPTION
This PR just fixes the version of Swiftz that's compatible with older versions of Swift, to tag the current version and prepare for the new updates.

Could you please review, @anamariamv?