### PR TITLE
Js 35 fix vector issues

### DIFF
--- a/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
+++ b/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		590992581B9DD61D008380B0 /* SecondBridge.xcworkspace in Resources */ = {isa = PBXBuildFile; fileRef = 590992571B9DD61D008380B0 /* SecondBridge.xcworkspace */; };
 		59283E531B0A03B500EC3A9F /* SecondBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = A183A1271AA85FA500C535A6 /* SecondBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		594E50371BC40B85005866FE /* ArraySlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594E50361BC40B85005866FE /* ArraySlice.swift */; settings = {ASSET_TAGS = (); }; };
+		594E50381BC40B85005866FE /* ArraySlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594E50361BC40B85005866FE /* ArraySlice.swift */; settings = {ASSET_TAGS = (); }; };
+		594E50391BC40B85005866FE /* ArraySlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 594E50361BC40B85005866FE /* ArraySlice.swift */; settings = {ASSET_TAGS = (); }; };
 		596D703D1AADB79B00CE9962 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D703C1AADB79B00CE9962 /* Map.swift */; };
 		596D703E1AADB79B00CE9962 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D703C1AADB79B00CE9962 /* Map.swift */; };
 		596D70421AADB80400CE9962 /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D70401AADB80400CE9962 /* MapTests.swift */; };
@@ -25,6 +28,7 @@
 		5982D6821AE647A100BA53D0 /* ArrayTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D6811AE647A100BA53D0 /* ArrayTTests.swift */; };
 		5982D68F1AE7B6DC00BA53D0 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
 		5982D6901AE7B6DC00BA53D0 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
+		599207CD1BC40D7800BB786D /* VectorIntegrityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599207CC1BC40D7800BB786D /* VectorIntegrityTests.swift */; settings = {ASSET_TAGS = (); }; };
 		59A911B11AEA2F6F00EE50CA /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A911B01AEA2F6F00EE50CA /* VectorTests.swift */; };
 		59A911B21AEA2F6F00EE50CA /* SecondBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A183A1221AA85FA500C535A6 /* SecondBridge.framework */; };
 		59A911B91AEA2F8000EE50CA /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
@@ -90,6 +94,7 @@
 		374373D53C1E1730C0517D5F /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		484FE31132DFCAEC6C987ABF /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		590992571B9DD61D008380B0 /* SecondBridge.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = SecondBridge.xcworkspace; sourceTree = "<group>"; };
+		594E50361BC40B85005866FE /* ArraySlice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySlice.swift; sourceTree = "<group>"; };
 		596D703C1AADB79B00CE9962 /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		596D70401AADB80400CE9962 /* MapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		597143121AC9369700C1217C /* TraversableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TraversableTests.swift; sourceTree = "<group>"; };
@@ -102,6 +107,7 @@
 		5981E3C81AB6DFE600F052A0 /* Traversable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Traversable.swift; sourceTree = "<group>"; };
 		5982D6811AE647A100BA53D0 /* ArrayTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTTests.swift; sourceTree = "<group>"; };
 		5982D68E1AE7B6DC00BA53D0 /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
+		599207CC1BC40D7800BB786D /* VectorIntegrityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VectorIntegrityTests.swift; sourceTree = "<group>"; };
 		59A911AC1AEA2F6F00EE50CA /* VectorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VectorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		59A911AF1AEA2F6F00EE50CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		59A911B01AEA2F6F00EE50CA /* VectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorTests.swift; sourceTree = "<group>"; };
@@ -198,6 +204,7 @@
 				59A911BD1AEA534A00EE50CA /* VectorPerformanceTests.swift */,
 				59A911AE1AEA2F6F00EE50CA /* Supporting Files */,
 				59B2C4D61AEE8BD200BA104C /* VectorTraversability.swift */,
+				599207CC1BC40D7800BB786D /* VectorIntegrityTests.swift */,
 			);
 			path = VectorTests;
 			sourceTree = "<group>";
@@ -214,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				59BBB24C1AC466BD00D2F7C1 /* Range.swift */,
+				594E50361BC40B85005866FE /* ArraySlice.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -522,6 +530,8 @@
 				59B2C4DE1AEE8C6400BA104C /* ArrayT.swift in Sources */,
 				59B2C4DF1AEE8C6400BA104C /* ListT.swift in Sources */,
 				59B2C4D91AEE8C5200BA104C /* Traversable.swift in Sources */,
+				594E50391BC40B85005866FE /* ArraySlice.swift in Sources */,
+				599207CD1BC40D7800BB786D /* VectorIntegrityTests.swift in Sources */,
 				59B2C4DA1AEE8C5200BA104C /* Iterable.swift in Sources */,
 				59A911B91AEA2F8000EE50CA /* Vector.swift in Sources */,
 				59B2C4D71AEE8BD200BA104C /* VectorTraversability.swift in Sources */,
@@ -538,6 +548,7 @@
 				5982D68F1AE7B6DC00BA53D0 /* Vector.swift in Sources */,
 				A1B6F0EB1AE4ECB3006E7997 /* Iterable.swift in Sources */,
 				59D811B71AA87B7C005F7761 /* HashableAny.swift in Sources */,
+				594E50371BC40B85005866FE /* ArraySlice.swift in Sources */,
 				596D703D1AADB79B00CE9962 /* Map.swift in Sources */,
 				5973D3081AD2A46200EBDE0B /* ArrayT.swift in Sources */,
 				597686161ACAA87B00756A9F /* Stack.swift in Sources */,
@@ -569,6 +580,7 @@
 				596D703E1AADB79B00CE9962 /* Map.swift in Sources */,
 				597686211ACAE0BA00756A9F /* NQueensExample.swift in Sources */,
 				5981E3CA1AB6DFE600F052A0 /* Traversable.swift in Sources */,
+				594E50381BC40B85005866FE /* ArraySlice.swift in Sources */,
 				A12A115B1AC31B2200FE8A80 /* RangeTests.swift in Sources */,
 				597143131AC9369700C1217C /* TraversableTests.swift in Sources */,
 			);

--- a/SecondBridge/SecondBridge/Data/Vector.swift
+++ b/SecondBridge/SecondBridge/Data/Vector.swift
@@ -1148,7 +1148,6 @@ extension VectorBuilder {
         var back = Vector<T>.Array2()
         
         for i in 0..<length {
-            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
             let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray1(buffer))
         }
@@ -1161,7 +1160,6 @@ extension VectorBuilder {
         var back = Vector<T>.Array3()
         
         for i in 0..<length {
-            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
             let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray2(buffer))
         }
@@ -1174,7 +1172,6 @@ extension VectorBuilder {
         var back = Vector<T>.Array4()
         
         for i in 0..<length {
-            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
             let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray3(buffer))
         }
@@ -1187,7 +1184,6 @@ extension VectorBuilder {
         var back = Vector<T>.Array5()
         
         for i in 0..<length {
-            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
             let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray4(buffer))
         }
@@ -1200,7 +1196,6 @@ extension VectorBuilder {
         var back = Vector<T>.Array6()
         
         for i in 0..<length {
-            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
             let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray5(buffer))
         }

--- a/SecondBridge/SecondBridge/Data/Vector.swift
+++ b/SecondBridge/SecondBridge/Data/Vector.swift
@@ -1148,7 +1148,8 @@ extension VectorBuilder {
         var back = Vector<T>.Array2()
         
         for i in 0..<length {
-            let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray1(buffer))
         }
         return back
@@ -1160,7 +1161,8 @@ extension VectorBuilder {
         var back = Vector<T>.Array3()
         
         for i in 0..<length {
-            let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray2(buffer))
         }
         return back
@@ -1172,7 +1174,8 @@ extension VectorBuilder {
         var back = Vector<T>.Array4()
         
         for i in 0..<length {
-            let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray3(buffer))
         }
         return back
@@ -1184,7 +1187,8 @@ extension VectorBuilder {
         var back = Vector<T>.Array5()
         
         for i in 0..<length {
-            let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray4(buffer))
         }
         return back
@@ -1196,7 +1200,8 @@ extension VectorBuilder {
         var back = Vector<T>.Array6()
         
         for i in 0..<length {
-            let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            //let buffer = seq[(i * cellSize..<min((i + 1) * cellSize, seq.count))]
+            let buffer = seq.sliceFromRangeWithZeroIndex((i * cellSize..<min((i + 1) * cellSize, seq.count)))
             back.append(fillArray5(buffer))
         }
         return back

--- a/SecondBridge/SecondBridge/Extension/ArraySlice.swift
+++ b/SecondBridge/SecondBridge/Extension/ArraySlice.swift
@@ -1,0 +1,23 @@
+/*
+* Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License. You may obtain
+* a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import Foundation
+
+extension ArraySlice {
+    func sliceFromRangeWithZeroIndex(range: Range<Int>) -> ArraySlice {
+        return self[range.startIndex + self.startIndex..<range.endIndex + self.startIndex]
+    }
+}

--- a/SecondBridge/VectorTests/VectorIntegrityTests.swift
+++ b/SecondBridge/VectorTests/VectorIntegrityTests.swift
@@ -25,9 +25,15 @@ class VectorIntegrityTests: XCTestCase {
     }
 
     func testIntegrity() {
-        for i in 0..<32 << 25 {
+        // Like in the Vector's level tests, the highest value for the integrity tests is commented out for sanity.
+        // You can play with the different Thresh values (i.e.: 32 << 5, 32 << 10, 32 << 15, 32 << 20 or 32 << 25),
+        // but the latest two will take hours to complete!
+        // let dataSize = 32 << 25
+        let dataSize = 32 << 10
+
+        for i in 0..<dataSize {
             extraBigVector = extraBigVector.append(i)
-            print("Integrity Test \((Float(i) / Float(32 << 25)) * 100)%")
+            print("Integrity Test \((Float(i) / Float(dataSize)) * 100)%")
             XCTAssert(extraBigVector[i] == i, "There are inconsistencies in Vector internal data")
         }
     }

--- a/SecondBridge/VectorTests/VectorIntegrityTests.swift
+++ b/SecondBridge/VectorTests/VectorIntegrityTests.swift
@@ -1,0 +1,34 @@
+/*
+* Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License. You may obtain
+* a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import XCTest
+
+class VectorIntegrityTests: XCTestCase {
+
+    var extraBigVector = Vector<Int>()
+    
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testIntegrity() {
+        for i in 0..<32 << 25 {
+            extraBigVector = extraBigVector.append(i)
+            print("Integrity Test \((Float(i) / Float(32 << 25)) * 100)%")
+            XCTAssert(extraBigVector[i] == i, "There are inconsistencies in Vector internal data")
+        }
+    }
+}

--- a/SecondBridge/VectorTests/VectorPerformanceTests.swift
+++ b/SecondBridge/VectorTests/VectorPerformanceTests.swift
@@ -89,27 +89,27 @@ class VectorPerformanceTests: XCTestCase {
     
     func testPerformanceAccessSmall() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorSmall.count)))
-                let value = self.vectorSmall[index]
+                _ = self.vectorSmall[index]
             }
         }
     }
     
     func testPerformanceAccessMedium() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorMedium.count)))
-                let value = self.vectorBig[index]
+                _ = self.vectorBig[index]
             }
         }
     }
     
     func testPerformanceAccessBig() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorMedium.count)))
-                let value = self.vectorBig[index]
+                _ = self.vectorBig[index]
             }
         }
     }
@@ -155,27 +155,27 @@ class VectorPerformanceTests: XCTestCase {
     
     func testPerformanceAccessArraySmall() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorSmall.count)))
-                let value = self.arraySmall[index]
+                _ = self.arraySmall[index]
             }
         }
     }
     
     func testPerformanceAccessArrayMedium() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorMedium.count)))
-                let value = self.arrayMedium[index]
+                _ = self.arrayMedium[index]
             }
         }
     }
     
     func testPerformanceAccessArrayBig() {
         self.measureBlock() {
-            for i in 0..<10 {
+            for _ in 0..<10 {
                 let index = Int(arc4random_uniform(UInt32(self.vectorMedium.count)))
-                let value = self.arrayBig[index]
+                _ = self.arrayBig[index]
             }
         }
     }


### PR DESCRIPTION
This PR includes a fix to Vectors for a problem introduced by Swift 2.0 with ArraySlices. It's taken care of. I've written an "integrity" test to check that everything is OK, but passing it completely (to a whole Vector - 4 GB) has been impossible. But I've taken it out to the fourth thresh and seems to work OK, so I think this problem is solved.

Could you please review, @anamariamv ?? Thanks!