### PR TITLE
Js 37 try monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ matchTest.apply(1000)		// "Moar!"
 
 **Try**
 
-`Try` is a monad that encapsulates an operation that can fail and throw an exception. As you may be aware, Swift now supports do-try-catch blocks to handle operations that can fail. `Try` can wrap throwable functions (those marked with the `throws` keyword) to handle these failures for you. The result of the wrapped operation is store in a `TryMatcher.Success(x)` if it's a valid result `x`, or `TryMatcher.Failure(ex)` if the operation has thrown an `ex` exception.
+`Try` is a monad that encapsulates an operation that can fail and throw an exception. As you may be aware, Swift now supports `do-try-catch` blocks to handle operations that can fail. `Try` can wrap throwable functions (those marked with the `throws` keyword) to handle these failures for you. The result of the wrapped operation is stored in a `TryMatcher.Success(x)` if it's a valid result `x`, or `TryMatcher.Failure(ex)` if the operation has thrown an `ex` exception.
 
 ```swift
 import SecondBridge
@@ -277,7 +277,6 @@ func tryHalf(n: Int) -> Try<Int> {
 let flatmapCorrectResultAgainstOKFunction = tryParseCorrectString.flatMap(tryHalf)
 flatmapCorrectResultAgainstOKFunction.isSuccess()	// true
 flatmapCorrectResultAgainstOKFunction.getOrElse(1)	// 23
-
 
 // You can also use `recover` and `recoverWith` to chain a set of
 // Partial Functions that can handle failures in your `Try`s:

--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ func convertStringToInt(s: String) throws -> Int {
 let tryParseCorrectString = Try<Int>(try self.convertStringToInt("47"))
 tryParseCorrectString.isFailure()					// false
 tryParseCorrectString.isSuccess()					// true
+
+// You can get the result of the operations through pattern matching...
+switch tryParseCorrectString.matchResult {
+        case .Success(let value): print("Result is \(value)")
+        case .Failure(let ex): print("There has been an exception!")
+        }
+
+// ...or using convenience functions like getOrElse
 let value = tryParseCorrectString.getOrElse(0)		// 47
 
 let tryParseIncorrectString = Try<Int>(try self.convertStringToInt("47 Degrees"))

--- a/README.md
+++ b/README.md
@@ -226,10 +226,61 @@ matchTest.apply(1)			// "One"
 matchTest.apply(1000)		// "Moar!"
 ```
 
+####  UTILS
+
+**Try**
+
+`Try` is a monad that encapsulates an operation that can fail and throw an exception. As you may be aware, Swift now supports do-try-catch blocks to handle operations that can fail. `Try` can wrap throwable functions (those marked with the `throws` keyword) to handle these failures for you. The result of the wrapped operation is store in a `TryMatcher.Success(x)` if it's a valid result `x`, or `TryMatcher.Failure(ex)ryMatcher.Failure(ex)` if the operation has thrown an `ex` exception.
+
+```swift
+import SecondBridge
+
+// Throwable function
+func convertStringToInt(s: String) throws -> Int {
+        if let parsedInt = Int(s) {
+            return parsedInt
+        } else {
+            throw ParseError.InvalidString
+        }
+    }
+
+let tryParseCorrectString = Try<Int>(try self.convertStringToInt("47"))
+tryParseCorrectString.isFailure()		// false
+tryParseCorrectString.isSuccess()	// true
+let value = tryParseCorrectString.getOrElse(0)		// 47
+
+let tryParseIncorrectString = Try<Int>(try self.convertStringToInt("47 Degrees"))
+tryParseCorrectString.isFailure()		// true
+tryParseCorrectString.isSuccess()	// false
+let invalidValue = tryParseIncorrectString.getOrElse(666)      // 666
+
+// You can apply several Higher-Order Functions to Try instances to apply functions to the encapsulated values:
+let f = { (n: Int) -> Int in n + 10 }
+let mapCorrectResult = tryParseCorrectString.map(f).getOrElse(666)      // 57
+
+let filterCorrectResult = tryParseCorrectString.filter({ $0 != 47 })     // .Failure(exception)
+
+func tryHalf(n: Int) -> Try<Int> { // Returns a Try containing a function that divides any Int by two }
+let flatmapCorrectResultAgainstOKFunction = tryParseCorrectString.flatMap(tryHalf)
+flatmapCorrectResultAgainstOKFunction.isSuccess()       // true
+flatmapCorrectResultAgainstOKFunction.getOrElse(1)     // 23
+
+
+// You can also use `recover` and `recoverWith` to chain a set of Partial Functions that can handle failures in your `Try`s:
+
+let recoverResult = tryParseIncorrectString.recover({
+            (e: ErrorType) -> Bool in
+                return true
+            } |-> {(e: ErrorType) -> (Int) in return 0})
+
+recoverResult.isSuccess()	// true
+let recoverResultGet = recoverResult.getOrElse(1)     // 0
+```
+
 System Requirements
 ==================
 
-Second Bridge supports iOS 8.0+.
+Second Bridge supports iOS 8.0+ and Swift 2.0.
 
 Contribute
 =========

--- a/README.md
+++ b/README.md
@@ -245,29 +245,30 @@ func convertStringToInt(s: String) throws -> Int {
     }
 
 let tryParseCorrectString = Try<Int>(try self.convertStringToInt("47"))
-tryParseCorrectString.isFailure()		// false
-tryParseCorrectString.isSuccess()	// true
+tryParseCorrectString.isFailure()					// false
+tryParseCorrectString.isSuccess()					// true
 let value = tryParseCorrectString.getOrElse(0)		// 47
 
 let tryParseIncorrectString = Try<Int>(try self.convertStringToInt("47 Degrees"))
-tryParseCorrectString.isFailure()		// true
-tryParseCorrectString.isSuccess()	// false
-let invalidValue = tryParseIncorrectString.getOrElse(666)      // 666
+tryParseCorrectString.isFailure()							// true
+tryParseCorrectString.isSuccess()							// false
+let invalidValue = tryParseIncorrectString.getOrElse(666)   // 666
 
 // You can apply several Higher-Order Functions to Try instances
 // to apply functions to the encapsulated values:
 let f = { (n: Int) -> Int in n + 10 }
-let mapCorrectResult = tryParseCorrectString.map(f).getOrElse(666)      // 57
+let mapCorrectResult = tryParseCorrectString.map(f).getOrElse(666)	// 57
 
-let filterCorrectResult = tryParseCorrectString.filter({ $0 != 47 })     // .Failure(exception)
+let filterCorrectResult = 
+	tryParseCorrectString.filter({ $0 != 47 })		// .Failure(exception)
 
 func tryHalf(n: Int) -> Try<Int> {
 	// Returns a Try containing a function that divides any Int by two
 	// ...
 }
 let flatmapCorrectResultAgainstOKFunction = tryParseCorrectString.flatMap(tryHalf)
-flatmapCorrectResultAgainstOKFunction.isSuccess()       // true
-flatmapCorrectResultAgainstOKFunction.getOrElse(1)     // 23
+flatmapCorrectResultAgainstOKFunction.isSuccess()	// true
+flatmapCorrectResultAgainstOKFunction.getOrElse(1)	// 23
 
 
 // You can also use `recover` and `recoverWith` to chain a set of
@@ -277,8 +278,8 @@ let recoverResult = tryParseIncorrectString.recover({
                 return true
             } |-> {(e: ErrorType) -> (Int) in return 0})
 
-recoverResult.isSuccess()	// true
-let recoverResultGet = recoverResult.getOrElse(1)     // 0
+recoverResult.isSuccess()								// true
+let recoverResultGet = recoverResult.getOrElse(1)		// 0
 ```
 
 System Requirements

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ matchTest.apply(1000)		// "Moar!"
 
 **Try**
 
-`Try` is a monad that encapsulates an operation that can fail and throw an exception. As you may be aware, Swift now supports do-try-catch blocks to handle operations that can fail. `Try` can wrap throwable functions (those marked with the `throws` keyword) to handle these failures for you. The result of the wrapped operation is store in a `TryMatcher.Success(x)` if it's a valid result `x`, or `TryMatcher.Failure(ex)ryMatcher.Failure(ex)` if the operation has thrown an `ex` exception.
+`Try` is a monad that encapsulates an operation that can fail and throw an exception. As you may be aware, Swift now supports do-try-catch blocks to handle operations that can fail. `Try` can wrap throwable functions (those marked with the `throws` keyword) to handle these failures for you. The result of the wrapped operation is store in a `TryMatcher.Success(x)` if it's a valid result `x`, or `TryMatcher.Failure(ex)` if the operation has thrown an `ex` exception.
 
 ```swift
 import SecondBridge

--- a/README.md
+++ b/README.md
@@ -237,12 +237,12 @@ import SecondBridge
 
 // Throwable function
 func convertStringToInt(s: String) throws -> Int {
-        if let parsedInt = Int(s) {
-            return parsedInt
-        } else {
-            throw ParseError.InvalidString
-        }
-    }
+     if let parsedInt = Int(s) {
+         return parsedInt
+     } else {
+         throw ParseError.InvalidString
+     }
+}
 
 let tryParseCorrectString = Try<Int>(try self.convertStringToInt("47"))
 tryParseCorrectString.isFailure()					// false
@@ -252,7 +252,7 @@ tryParseCorrectString.isSuccess()					// true
 switch tryParseCorrectString.matchResult {
         case .Success(let value): print("Result is \(value)")
         case .Failure(let ex): print("There has been an exception!")
-        }
+}
 
 // ...or using convenience functions like getOrElse
 let value = tryParseCorrectString.getOrElse(0)		// 47

--- a/README.md
+++ b/README.md
@@ -254,20 +254,24 @@ tryParseCorrectString.isFailure()		// true
 tryParseCorrectString.isSuccess()	// false
 let invalidValue = tryParseIncorrectString.getOrElse(666)      // 666
 
-// You can apply several Higher-Order Functions to Try instances to apply functions to the encapsulated values:
+// You can apply several Higher-Order Functions to Try instances
+// to apply functions to the encapsulated values:
 let f = { (n: Int) -> Int in n + 10 }
 let mapCorrectResult = tryParseCorrectString.map(f).getOrElse(666)      // 57
 
 let filterCorrectResult = tryParseCorrectString.filter({ $0 != 47 })     // .Failure(exception)
 
-func tryHalf(n: Int) -> Try<Int> { // Returns a Try containing a function that divides any Int by two }
+func tryHalf(n: Int) -> Try<Int> {
+	// Returns a Try containing a function that divides any Int by two
+	// ...
+}
 let flatmapCorrectResultAgainstOKFunction = tryParseCorrectString.flatMap(tryHalf)
 flatmapCorrectResultAgainstOKFunction.isSuccess()       // true
 flatmapCorrectResultAgainstOKFunction.getOrElse(1)     // 23
 
 
-// You can also use `recover` and `recoverWith` to chain a set of Partial Functions that can handle failures in your `Try`s:
-
+// You can also use `recover` and `recoverWith` to chain a set of
+// Partial Functions that can handle failures in your `Try`s:
 let recoverResult = tryParseIncorrectString.recover({
             (e: ErrorType) -> Bool in
                 return true

--- a/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
+++ b/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		590992581B9DD61D008380B0 /* SecondBridge.xcworkspace in Resources */ = {isa = PBXBuildFile; fileRef = 590992571B9DD61D008380B0 /* SecondBridge.xcworkspace */; };
+		5927AF651BC5066A00161247 /* TryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5927AF641BC5066A00161247 /* TryTests.swift */; settings = {ASSET_TAGS = (); }; };
 		59283E531B0A03B500EC3A9F /* SecondBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = A183A1271AA85FA500C535A6 /* SecondBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		596D703D1AADB79B00CE9962 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D703C1AADB79B00CE9962 /* Map.swift */; };
 		596D703E1AADB79B00CE9962 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596D703C1AADB79B00CE9962 /* Map.swift */; };
@@ -92,6 +93,7 @@
 		374373D53C1E1730C0517D5F /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		484FE31132DFCAEC6C987ABF /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		590992571B9DD61D008380B0 /* SecondBridge.xcworkspace */ = {isa = PBXFileReference; lastKnownFileType = wrapper.workspace; path = SecondBridge.xcworkspace; sourceTree = "<group>"; };
+		5927AF641BC5066A00161247 /* TryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TryTests.swift; sourceTree = "<group>"; };
 		596D703C1AADB79B00CE9962 /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Map.swift; sourceTree = "<group>"; };
 		596D70401AADB80400CE9962 /* MapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		597143121AC9369700C1217C /* TraversableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TraversableTests.swift; sourceTree = "<group>"; };
@@ -166,6 +168,14 @@
 				374373D53C1E1730C0517D5F /* Pods.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5927AF631BC5065800161247 /* ErrorHandling */ = {
+			isa = PBXGroup;
+			children = (
+				5927AF641BC5066A00161247 /* TryTests.swift */,
+			);
+			path = ErrorHandling;
 			sourceTree = "<group>";
 		};
 		597143101AC9368800C1217C /* Protocols */ = {
@@ -334,6 +344,7 @@
 		A183A1311AA85FA500C535A6 /* SecondBridgeTests */ = {
 			isa = PBXGroup;
 			children = (
+				5927AF631BC5065800161247 /* ErrorHandling */,
 				597143101AC9368800C1217C /* Protocols */,
 				A12A11591AC31B2200FE8A80 /* Extension */,
 				59C9BCAC1AC2DD500043C96E /* Functions */,
@@ -585,6 +596,7 @@
 				5981E3CA1AB6DFE600F052A0 /* Traversable.swift in Sources */,
 				A12A115B1AC31B2200FE8A80 /* RangeTests.swift in Sources */,
 				597143131AC9369700C1217C /* TraversableTests.swift in Sources */,
+				5927AF651BC5066A00161247 /* TryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
+++ b/SecondBridge/SecondBridge.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		5982D6821AE647A100BA53D0 /* ArrayTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D6811AE647A100BA53D0 /* ArrayTTests.swift */; };
 		5982D68F1AE7B6DC00BA53D0 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
 		5982D6901AE7B6DC00BA53D0 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
+		599207D01BC4174400BB786D /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599207CF1BC4174400BB786D /* Try.swift */; settings = {ASSET_TAGS = (); }; };
+		599207D11BC4174400BB786D /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599207CF1BC4174400BB786D /* Try.swift */; settings = {ASSET_TAGS = (); }; };
 		59A911B11AEA2F6F00EE50CA /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A911B01AEA2F6F00EE50CA /* VectorTests.swift */; };
 		59A911B21AEA2F6F00EE50CA /* SecondBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A183A1221AA85FA500C535A6 /* SecondBridge.framework */; };
 		59A911B91AEA2F8000EE50CA /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5982D68E1AE7B6DC00BA53D0 /* Vector.swift */; };
@@ -102,6 +104,7 @@
 		5981E3C81AB6DFE600F052A0 /* Traversable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Traversable.swift; sourceTree = "<group>"; };
 		5982D6811AE647A100BA53D0 /* ArrayTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTTests.swift; sourceTree = "<group>"; };
 		5982D68E1AE7B6DC00BA53D0 /* Vector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
+		599207CF1BC4174400BB786D /* Try.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Try.swift; sourceTree = "<group>"; };
 		59A911AC1AEA2F6F00EE50CA /* VectorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VectorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		59A911AF1AEA2F6F00EE50CA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		59A911B01AEA2F6F00EE50CA /* VectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorTests.swift; sourceTree = "<group>"; };
@@ -189,6 +192,14 @@
 				59800BFA1AD6BD200044D0ED /* Iterable.swift */,
 			);
 			path = Protocols;
+			sourceTree = "<group>";
+		};
+		599207CE1BC4173800BB786D /* ErrorHandling */ = {
+			isa = PBXGroup;
+			children = (
+				599207CF1BC4174400BB786D /* Try.swift */,
+			);
+			path = ErrorHandling;
 			sourceTree = "<group>";
 		};
 		59A911AD1AEA2F6F00EE50CA /* VectorTests */ = {
@@ -301,6 +312,7 @@
 		A183A1241AA85FA500C535A6 /* SecondBridge */ = {
 			isa = PBXGroup;
 			children = (
+				599207CE1BC4173800BB786D /* ErrorHandling */,
 				59BBB24A1AC466BD00D2F7C1 /* Extension */,
 				59C9BCA71AC2DD440043C96E /* Functions */,
 				59D811B21AA87B3B005F7761 /* Data */,
@@ -544,6 +556,7 @@
 				59BBB24E1AC466BD00D2F7C1 /* Range.swift in Sources */,
 				5981E3C91AB6DFE600F052A0 /* Traversable.swift in Sources */,
 				59C9BCA91AC2DD440043C96E /* PartialFunction.swift in Sources */,
+				599207D01BC4174400BB786D /* Try.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,6 +564,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				599207D11BC4174400BB786D /* Try.swift in Sources */,
 				59BDBCEA1ADFB2C400FFA363 /* ListT.swift in Sources */,
 				59BDBCEB1ADFB2C400FFA363 /* Iterable.swift in Sources */,
 				59BDBCEC1ADFB2C400FFA363 /* IterableTests.swift in Sources */,

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -1,26 +1,41 @@
-//
-//  Try.swift
-//  SecondBridge
-//
-//  Created by Javier de Silóniz Sandino on 6/10/15.
-//  Copyright © 2015 47 Degrees. All rights reserved.
-//
+/*
+* Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may
+* not use this file except in compliance with the License. You may obtain
+* a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 import Foundation
+import Swiftz
 
-enum TryMatcher<T> {
+// MARK: - Try pattern matching helpers
+public enum TryMatcher<T> {
     case Success(T)
     case Failure(ErrorType)
 }
 
-enum TryError : ErrorType {
+private enum TryError : ErrorType {
     case TryFilterException
 }
 
+// MARK: - Try definition
+/// Defines a computation that either result in an exception, or return a successfully computed value.
 struct Try<T> {
     private let matchResult : TryMatcher<T>
     
-    init(@autoclosure op: (() throws -> T)) {
+    /**
+    - parameter op: A throwable computation to be executed and encapsulated
+    */
+    internal init(@autoclosure _ op: (() throws -> T)) {
         do {
             let result = try op()
             matchResult = TryMatcher<T>.Success(result)
@@ -29,35 +44,39 @@ struct Try<T> {
         }
     }
     
-    init(m: TryMatcher<T>) {
+    /**
+    Utility constructor to allow compatibility between Try and its match cases (Success and Failure).
+    - parameter m: a Success or Failure enum case.
+    */
+    internal init(_ m: TryMatcher<T>) {
         matchResult = m
     }
-    
-    func match() -> TryMatcher<T> {
-        return matchResult
-    }
-    
-    func isSuccess() -> Bool {
-        switch self.match() {
+}
+
+extension Try {
+    /**
+    - returns: `true` if the encapsulated computation didn't throw an exception.
+    */
+    internal func isSuccess() -> Bool {
+        switch self.matchResult {
         case .Success(_): return true
         default: return false
         }
     }
     
-    func isFailure() -> Bool {
+    /**
+    - returns: `true` if the encapsulated computation did throw an exception.
+    */
+    internal func isFailure() -> Bool {
         return !self.isSuccess()
     }
     
-    func get() -> T? {
-        switch self.match() {
-        case .Success(let value): return value
-        case .Failure(let ex): try! forceThrow(ex)
-        }
-        return nil
-    }
-    
-    func getOrElse(def: T) -> T {
-        switch self.match() {
+    /**
+    - parameter def: A default value to return if the encapsulated computation throws an exception.
+    - returns: The result of the encapsulated computation, or a default value if it did throw an exception.
+    */
+    internal func getOrElse(def: T) -> T {
+        switch self.matchResult {
         case .Success(let value): return value
         case .Failure(_): return def
         }
@@ -67,28 +86,120 @@ struct Try<T> {
         throw(ex)
     }
     
-    func map<B>(f: T -> B) -> Try<B> {
-        switch self.match() {
-        case .Success(let value): return Try<B>(m: TryMatcher.Success(f(value)))
-        case .Failure(let ex): return Try<B>(m: TryMatcher.Failure(ex))
-        }
-    }
-    
-    func flatMap<B>(f: T -> Try<B>) -> Try<B> {
-        switch self.match() {
-        case .Success(let value): return f(value)
-        case .Failure(let ex): return Try<B>(m: TryMatcher.Failure(ex))
-        }
-    }
-    
-    func filter(f: T -> Bool) -> Try {
-        switch self.match() {
+    /**
+    - parameter f: A function to filter the result of a computation.
+    - returns: Success(x) if the original computation was successful and `f(x)` is `true`. Failure(ex: TryFilterException)
+    in case the filter function returned `false`. If the original computation was a failure, it just goes through.
+    */
+    internal func filter(f: T -> Bool) -> Try {
+        switch self.matchResult {
         case .Success(let value):
             if f(value) {
                 return self
             }
-            return Try(m: TryMatcher.Failure(TryError.TryFilterException))
+            return Try(.Failure(TryError.TryFilterException))
         case .Failure(_): return self
+        }
+    }
+    
+    /**
+    Allows recovering from a Failure operation, by applying one of the given partial functions. These partial functions will be 
+    evaluated sequentially as in a Pattern Matching. The matching function will be wrapped in a Try and returned to the user.
+    - parameter pf: A variadic list of partial functions that will be evaluated as in a Pattern Matching. The result of this process
+    will be wrapped in a Try and returned to the user.
+    */
+    internal func recover(pf: PartialFunction<ErrorType, T>...) -> Try<T> {
+        return recoverWithArray(pf.map{ $0.flatMap { (x: T) -> Try<T> in return Try(x) }})
+    }
+    
+    /**
+    Allows recovering from a Failure operation, by applying one of the given partial functions. These partial functions will be
+    evaluated sequentially as in a Pattern Matching. The matching function will be returned to the user.
+    - parameter pf: A variadic list of partial functions that will be evaluated as in a Pattern Matching. The result of this process
+    will be wrapped in a Try and returned to the user.
+    */
+    internal func recoverWith(pf: PartialFunction<ErrorType, Try<T>>...) -> Try<T> {
+        return recoverWithArray(pf)
+    }
+    
+    private func recoverWithArray(pf: [PartialFunction<ErrorType, Try<T>>]) -> Try<T> {
+        switch self.matchResult {
+        case .Success(_): return self
+        case .Failure(let ex): return match(pf).apply(ex)
+        }
+    }
+}
+
+extension Try: Applicative {
+    typealias A = T
+    typealias B = Any
+    typealias FB = Try<B>
+    typealias FAB = Try<A -> B>
+    
+    /**
+    - returns: A `Try` instance wrapping a given value. (Serves as a Point function).
+    - parameter a: A value to be wrapped in a Try.
+    */
+    static func pure(a : A) -> Try {
+        return Try(a)
+    }
+    
+    /**
+    - parameter f: A transformation function between the type for our given `Try`, and another type `B`.
+    - returns: If our given `Try` is a `Success(x)`, it will return `Try(f(x))`. If not, it will wrap the original
+    exception to a `Try` of type `B`.
+    */
+    internal func map<B>(f: T -> B) -> Try<B> {
+        switch self.matchResult {
+        case .Success(let value): return Try<B>(.Success(f(value)))
+        case .Failure(let ex): return Try<B>(.Failure(ex))
+        }
+    }
+    
+    /**
+    - parameter f: A transformation function between the type for our given `Try`, and another type `B`.
+    - returns: If our given `Try` is a `Success(x)`, it will return `Try(f(x))`. If not, it will wrap the original
+    exception to a `Try` of type `B`.
+    */
+    internal func fmap<B>(f : A -> B) -> FB {
+        return map({ f($0) })
+    }
+    
+    /**
+    Applies the function contained inside the provided Try `f`, to the value inside our given `Try` (if it's a `Success`).
+    If any of the `Try` instances is a `Failure`, the corresponding exception will fall through and returned to the user.
+    - parameter f: A `Try` containing a function of type `F -> B`
+    - returns: A `Try` containing the application of the function contained in `f` if both `f` and our given `Try` are
+    `Success`. If not, the corresponding exception will be returned wrapped in a `Try` of type `B`.
+    */
+    func ap(f : FAB) -> FB {
+        switch (self.matchResult, f.matchResult) {
+        case (.Failure(let ex), _): return Try<B>(.Failure(ex))
+        case (.Success(_), .Success(let fs)): return self.map(fs)
+        case (.Success(_), .Failure(let ex)): return Try<B>(.Failure(ex))
+        }
+    }
+}
+
+extension Try: Monad {
+    /**
+    - parameter f: A transformation function between the type for our given `Try`, and another `Try` of type `B`.
+    - returns: If our given `Try` is a `Success(x)`, it will return a `Try` containing the result of `f(x)`.
+    If not, it will wrap the original exception to a `Try` of type `B`.
+    */
+    func bind(f: Try.A -> Try.FB) -> Try.FB {
+        return self.flatMap(f)
+    }
+    
+    /**
+    - parameter f: A transformation function between the type for our given `Try`, and another `Try` of type `B`.
+    - returns: If our given `Try` is a `Success(x)`, it will return a `Try` containing the result of `f(x)`.
+    If not, it will wrap the original exception to a `Try` of type `B`.
+    */
+    internal func flatMap<B>(f: T -> Try<B>) -> Try<B> {
+        switch self.matchResult {
+        case .Success(let value): return f(value)
+        case .Failure(let ex): return Try<B>(.Failure(ex))
         }
     }
 }

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -29,13 +29,13 @@ private enum TryError : ErrorType {
 
 // MARK: - Try definition
 /// Defines a computation that either result in an exception, or return a successfully computed value.
-struct Try<T> {
+public struct Try<T> {
     private let matchResult : TryMatcher<T>
     
     /**
     - parameter op: A throwable computation to be executed and encapsulated
     */
-    internal init(@autoclosure _ op: (() throws -> T)) {
+    public init(@autoclosure _ op: (() throws -> T)) {
         do {
             let result = try op()
             matchResult = TryMatcher<T>.Success(result)
@@ -48,7 +48,7 @@ struct Try<T> {
     Utility constructor to allow compatibility between Try and its match cases (Success and Failure).
     - parameter m: a Success or Failure enum case.
     */
-    internal init(_ m: TryMatcher<T>) {
+    public init(_ m: TryMatcher<T>) {
         matchResult = m
     }
 }
@@ -57,7 +57,7 @@ extension Try {
     /**
     - returns: `true` if the encapsulated computation didn't throw an exception.
     */
-    internal func isSuccess() -> Bool {
+    public func isSuccess() -> Bool {
         switch self.matchResult {
         case .Success(_): return true
         default: return false
@@ -67,7 +67,7 @@ extension Try {
     /**
     - returns: `true` if the encapsulated computation did throw an exception.
     */
-    internal func isFailure() -> Bool {
+    public func isFailure() -> Bool {
         return !self.isSuccess()
     }
     
@@ -75,7 +75,7 @@ extension Try {
     - parameter def: A default value to return if the encapsulated computation throws an exception.
     - returns: The result of the encapsulated computation, or a default value if it did throw an exception.
     */
-    internal func getOrElse(def: T) -> T {
+    public func getOrElse(def: T) -> T {
         switch self.matchResult {
         case .Success(let value): return value
         case .Failure(_): return def
@@ -91,7 +91,7 @@ extension Try {
     - returns: Success(x) if the original computation was successful and `f(x)` is `true`. Failure(ex: TryFilterException)
     in case the filter function returned `false`. If the original computation was a failure, it just goes through.
     */
-    internal func filter(f: T -> Bool) -> Try {
+    public func filter(f: T -> Bool) -> Try {
         switch self.matchResult {
         case .Success(let value):
             if f(value) {
@@ -108,7 +108,7 @@ extension Try {
     - parameter pf: A variadic list of partial functions that will be evaluated as in a Pattern Matching. The result of this process
     will be wrapped in a Try and returned to the user.
     */
-    internal func recover(pf: PartialFunction<ErrorType, T>...) -> Try<T> {
+    public func recover(pf: PartialFunction<ErrorType, T>...) -> Try<T> {
         return recoverWithArray(pf.map{ $0.flatMap { (x: T) -> Try<T> in return Try(x) }})
     }
     
@@ -118,7 +118,7 @@ extension Try {
     - parameter pf: A variadic list of partial functions that will be evaluated as in a Pattern Matching. The result of this process
     will be wrapped in a Try and returned to the user.
     */
-    internal func recoverWith(pf: PartialFunction<ErrorType, Try<T>>...) -> Try<T> {
+    public func recoverWith(pf: PartialFunction<ErrorType, Try<T>>...) -> Try<T> {
         return recoverWithArray(pf)
     }
     
@@ -131,16 +131,16 @@ extension Try {
 }
 
 extension Try: Applicative {
-    typealias A = T
-    typealias B = Any
-    typealias FB = Try<B>
-    typealias FAB = Try<A -> B>
+    public typealias A = T
+    public typealias B = Any
+    public typealias FB = Try<B>
+    public typealias FAB = Try<A -> B>
     
     /**
     - returns: A `Try` instance wrapping a given value. (Serves as a Point function).
     - parameter a: A value to be wrapped in a Try.
     */
-    static func pure(a : A) -> Try {
+    public static func pure(a : A) -> Try {
         return Try(a)
     }
     
@@ -149,7 +149,7 @@ extension Try: Applicative {
     - returns: If our given `Try` is a `Success(x)`, it will return `Try(f(x))`. If not, it will wrap the original
     exception to a `Try` of type `B`.
     */
-    internal func map<B>(f: T -> B) -> Try<B> {
+    public func map<B>(f: T -> B) -> Try<B> {
         switch self.matchResult {
         case .Success(let value): return Try<B>(.Success(f(value)))
         case .Failure(let ex): return Try<B>(.Failure(ex))
@@ -161,7 +161,7 @@ extension Try: Applicative {
     - returns: If our given `Try` is a `Success(x)`, it will return `Try(f(x))`. If not, it will wrap the original
     exception to a `Try` of type `B`.
     */
-    internal func fmap<B>(f : A -> B) -> FB {
+    public func fmap<B>(f : A -> B) -> FB {
         return map({ f($0) })
     }
     
@@ -172,7 +172,7 @@ extension Try: Applicative {
     - returns: A `Try` containing the application of the function contained in `f` if both `f` and our given `Try` are
     `Success`. If not, the corresponding exception will be returned wrapped in a `Try` of type `B`.
     */
-    func ap(f : FAB) -> FB {
+    public func ap(f : FAB) -> FB {
         switch (self.matchResult, f.matchResult) {
         case (.Failure(let ex), _): return Try<B>(.Failure(ex))
         case (.Success(_), .Success(let fs)): return self.map(fs)
@@ -187,7 +187,7 @@ extension Try: Monad {
     - returns: If our given `Try` is a `Success(x)`, it will return a `Try` containing the result of `f(x)`.
     If not, it will wrap the original exception to a `Try` of type `B`.
     */
-    func bind(f: Try.A -> Try.FB) -> Try.FB {
+    public func bind(f: Try.A -> Try.FB) -> Try.FB {
         return self.flatMap(f)
     }
     
@@ -196,7 +196,7 @@ extension Try: Monad {
     - returns: If our given `Try` is a `Success(x)`, it will return a `Try` containing the result of `f(x)`.
     If not, it will wrap the original exception to a `Try` of type `B`.
     */
-    internal func flatMap<B>(f: T -> Try<B>) -> Try<B> {
+    public func flatMap<B>(f: T -> Try<B>) -> Try<B> {
         switch self.matchResult {
         case .Success(let value): return f(value)
         case .Failure(let ex): return Try<B>(.Failure(ex))

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -13,18 +13,24 @@ enum TryMatcher<T> {
     case Failure(ErrorType)
 }
 
+enum TryError : ErrorType {
+    case TryFilterException
+}
+
 struct Try<T> {
-    private let operation : (() throws -> T)
     private let matchResult : TryMatcher<T>
     
-    init(op: (() throws -> T)) {
-        operation = op
+    init(@autoclosure op: (() throws -> T)) {
         do {
             let result = try op()
             matchResult = TryMatcher<T>.Success(result)
         } catch let e {
             matchResult = TryMatcher<T>.Failure(e)
         }
+    }
+    
+    init(m: TryMatcher<T>) {
+        matchResult = m
     }
     
     func match() -> TryMatcher<T> {
@@ -50,10 +56,10 @@ struct Try<T> {
         return nil
     }
     
-    func getOrElse() -> T? {
+    func getOrElse(def: T) -> T {
         switch self.match() {
         case .Success(let value): return value
-        case .Failure(_): return nil
+        case .Failure(_): return def
         }
     }
     
@@ -61,5 +67,28 @@ struct Try<T> {
         throw(ex)
     }
     
+    func map<B>(f: T -> B) -> Try<B> {
+        switch self.match() {
+        case .Success(let value): return Try<B>(m: TryMatcher.Success(f(value)))
+        case .Failure(let ex): return Try<B>(m: TryMatcher.Failure(ex))
+        }
+    }
     
+    func flatMap<B>(f: T -> Try<B>) -> Try<B> {
+        switch self.match() {
+        case .Success(let value): return f(value)
+        case .Failure(let ex): return Try<B>(m: TryMatcher.Failure(ex))
+        }
+    }
+    
+    func filter(f: T -> Bool) -> Try {
+        switch self.match() {
+        case .Success(let value):
+            if f(value) {
+                return self
+            }
+            return Try(m: TryMatcher.Failure(TryError.TryFilterException))
+        case .Failure(_): return self
+        }
+    }
 }

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -1,0 +1,58 @@
+//
+//  Try.swift
+//  SecondBridge
+//
+//  Created by Javier de Silóniz Sandino on 6/10/15.
+//  Copyright © 2015 47 Degrees. All rights reserved.
+//
+
+import Foundation
+
+enum TryMatcher<T> {
+    case Success(T)
+    case Failure(ErrorType)
+}
+
+struct Try<T> {
+    private let operation : (() throws -> T)
+    private let matchResult : TryMatcher<T>
+    
+    init(op: (() throws -> T)) {
+        operation = op
+        do {
+            let result = try op()
+            matchResult = TryMatcher<T>.Success(result)
+        } catch let e {
+            matchResult = TryMatcher<T>.Failure(e)
+        }
+    }
+    
+    func match() -> TryMatcher<T> {
+        return matchResult
+    }
+    
+    func isSuccess() -> Bool {
+        switch self.match() {
+        case .Success(_): return true
+        default: return false
+        }
+    }
+    
+    func isFailure() -> Bool {
+        return !self.isSuccess()
+    }
+    
+    func get() -> T? {
+        switch self.match() {
+        case .Success(let value): return value
+        case .Failure(let ex): try! forceThrow(ex)
+        }
+        return nil
+    }
+    
+    private func forceThrow(ex: ErrorType) throws {
+        throw(ex)
+    }
+    
+    
+}

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -50,6 +50,13 @@ struct Try<T> {
         return nil
     }
     
+    func getOrElse() -> T? {
+        switch self.match() {
+        case .Success(let value): return value
+        case .Failure(_): return nil
+        }
+    }
+    
     private func forceThrow(ex: ErrorType) throws {
         throw(ex)
     }

--- a/SecondBridge/SecondBridge/ErrorHandling/Try.swift
+++ b/SecondBridge/SecondBridge/ErrorHandling/Try.swift
@@ -30,7 +30,7 @@ private enum TryError : ErrorType {
 // MARK: - Try definition
 /// Defines a computation that either result in an exception, or return a successfully computed value.
 public struct Try<T> {
-    private let matchResult : TryMatcher<T>
+    public let matchResult : TryMatcher<T>
     
     /**
     - parameter op: A throwable computation to be executed and encapsulated

--- a/SecondBridge/SecondBridge/Functions/PartialFunction.swift
+++ b/SecondBridge/SecondBridge/Functions/PartialFunction.swift
@@ -40,6 +40,27 @@ public struct PartialFunction<T, U> {
     }
 }
 
+public extension PartialFunction {
+    /**
+    Executes a given Partial Function.
+    - parameter i: The parameter to be passed to the internal function.
+    - returns: The result of the computation. Warning: the caller of `apply` is responsible of checking that the
+    given parameter is among the values defined by `isDefinedAt`.
+    */
+    func apply(i: T) -> U {
+        return self.function.apply(i)
+    }
+    
+    /**
+    Creates a new Partial Function, defining the same set of values for its entry, but applying the function `f`
+    to the result of the original computation.
+    - parameter f: The function to apply.
+    */
+    func flatMap<V>(f: U -> V) -> PartialFunction<T, V> {
+        return PartialFunction<T, V>(function: function >>> Function(f), isDefinedAt: isDefinedAt)
+    }
+}
+
 // MARK: - Or else / And then implementation
 
 /**
@@ -69,6 +90,16 @@ it will return the last of the given list which is implicitly considered as a de
 Users of `match` are responsible of making sure that the last function supplied is executable for all given values.
 */
 public func match<T, U>(listOfPartialFunctions: PartialFunction<T, U>...) -> Function<T, U> {
+    return match(listOfPartialFunctions)
+}
+
+/**
+Returns the first of the given list of Partial Functions to be satisfied by the given value `x`. If it doesn't satisfy any of them,
+it will return the last of the given list which is implicitly considered as a default function.
+
+Users of `match` are responsible of making sure that the last function supplied is executable for all given values.
+*/
+public func match<T, U>(listOfPartialFunctions: [PartialFunction<T, U>]) -> Function<T, U> {
     return Function.arr({ (x: T) -> U in
         let functions = listOfPartialFunctions.filter({ (item: PartialFunction<T, U>) -> Bool in
             return item.isDefinedAt.apply(x)

--- a/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
+++ b/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
@@ -1,0 +1,40 @@
+//
+//  TryTests.swift
+//  SecondBridge
+//
+//  Created by Javier de Silóniz Sandino on 7/10/15.
+//  Copyright © 2015 47 Degrees. All rights reserved.
+//
+
+import XCTest
+
+class TryTests: XCTestCase {
+
+    enum ParseError : ErrorType {
+        case InvalidString
+    }
+    
+    func convertStringToInt(s: String) throws -> Int {
+        if let parsedInt = Int(s) {
+            return parsedInt
+        } else {
+            throw ParseError.InvalidString
+        }
+    }
+
+    func testTryBasicBehaviour() {
+        let tryParseCorrectString = Try<Int>(op: {() throws -> Int in try self.convertStringToInt("47")})
+        XCTAssertTrue(tryParseCorrectString.isSuccess(), "Correct operation inside a Try should be a success")
+        XCTAssertFalse(tryParseCorrectString.isFailure(), "Correct operation inside a Try shouldn't be a failure")
+        let value = tryParseCorrectString.getOrElse()
+        XCTAssertNotNil(value, "Correct operation inside a Try should yield a value")
+        XCTAssertEqual(value, 47, "Correct operation inside a Try should yield the expected value")
+        
+        let tryParseIncorrectString = Try<Int>(op: {() throws -> Int in try self.convertStringToInt("47 Degrees")})
+        XCTAssertFalse(tryParseIncorrectString.isSuccess(), "Invalid operation inside a Try shouldn't be a success")
+        XCTAssertTrue(tryParseIncorrectString.isFailure(), "Invalid operation inside a Try should be a failure")
+        let invalidValue = tryParseIncorrectString.getOrElse()
+        XCTAssertNil(invalidValue, "Invalid operation inside a Try shouldn't yield a value")
+    }
+
+}

--- a/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
+++ b/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
@@ -14,6 +14,10 @@ class TryTests: XCTestCase {
         case InvalidString
     }
     
+    enum OperationError: ErrorType {
+        case DivideByZero
+    }
+    
     func convertStringToInt(s: String) throws -> Int {
         if let parsedInt = Int(s) {
             return parsedInt
@@ -21,20 +25,69 @@ class TryTests: XCTestCase {
             throw ParseError.InvalidString
         }
     }
+    
+    func halfOf(n: Int) -> Try<Int> {
+        return Try<Int>(op: (n / 2))
+    }
+    
+    func divideInt(n: Int, by: Int) throws -> Int {
+        switch by {
+        case 0: throw OperationError.DivideByZero
+        default: return n / by
+        }
+    }
+    
+    func tryDivideByZeroWhoops(n: Int) -> Try<Int> {
+        return Try<Int>(op: (try divideInt(n, by: 0)))
+    }
+    
+    func tryHalf(n: Int) -> Try<Int> {
+        return Try<Int>(op: (try divideInt(n, by: 2)))
+    }
 
     func testTryBasicBehaviour() {
-        let tryParseCorrectString = Try<Int>(op: {() throws -> Int in try self.convertStringToInt("47")})
+        let tryParseCorrectString = Try<Int>(op: try self.convertStringToInt("47"))
         XCTAssertTrue(tryParseCorrectString.isSuccess(), "Correct operation inside a Try should be a success")
         XCTAssertFalse(tryParseCorrectString.isFailure(), "Correct operation inside a Try shouldn't be a failure")
-        let value = tryParseCorrectString.getOrElse()
+        let value = tryParseCorrectString.get()
         XCTAssertNotNil(value, "Correct operation inside a Try should yield a value")
         XCTAssertEqual(value, 47, "Correct operation inside a Try should yield the expected value")
         
-        let tryParseIncorrectString = Try<Int>(op: {() throws -> Int in try self.convertStringToInt("47 Degrees")})
+        let tryParseIncorrectString = Try<Int>(op: try self.convertStringToInt("47 Degrees"))
         XCTAssertFalse(tryParseIncorrectString.isSuccess(), "Invalid operation inside a Try shouldn't be a success")
         XCTAssertTrue(tryParseIncorrectString.isFailure(), "Invalid operation inside a Try should be a failure")
-        let invalidValue = tryParseIncorrectString.getOrElse()
-        XCTAssertNil(invalidValue, "Invalid operation inside a Try shouldn't yield a value")
+        let invalidValue = tryParseIncorrectString.getOrElse(666)
+        XCTAssertEqual(invalidValue, 666, "Invalid operation inside a Try shouldn't yield a value")
+    }
+    
+    func testTryHigherOrderFunctions() {
+        let tryParseCorrectString = Try<Int>(op: try self.convertStringToInt("47"))
+        let tryParseIncorrectString = Try<Int>(op: try self.convertStringToInt("47 Degrees"))
+        
+        let mapCorrectResult = tryParseCorrectString.map({ $0 + 10 }).getOrElse(666)
+        XCTAssertEqual(mapCorrectResult, 57, "Mapping over a successful Try should yield a correct value")
+        
+        let mapIncorrectResult = tryParseIncorrectString.map({ $0 + 10 }).getOrElse(666)
+        XCTAssertEqual(mapIncorrectResult, 666, "Mapping over a failed Try shouldn't yield a correct value")
+        
+        let filterCorrectResult = tryParseCorrectString.filter({ $0 != 47 })
+        XCTAssert(filterCorrectResult.isFailure(), "A Success filtered with an invalid predicate should be changed to a Failure")
+        
+        let filterIncorrectResult = tryParseIncorrectString.filter({ $0 != 47 })
+        XCTAssert(filterIncorrectResult.isFailure(), "A Failure filtered with any predicate should be returned as such")
+        
+        let flatmapCorrectResultAgainstWrongFunction = tryParseCorrectString.flatMap(tryDivideByZeroWhoops)
+        XCTAssertTrue(flatmapCorrectResultAgainstWrongFunction.isFailure(), "When flatmapping a Success against a Failure, we should get a Failure")
+        
+        let flatmapCorrectResultAgainstOKFunction = tryParseCorrectString.flatMap(tryHalf)
+        XCTAssertTrue(flatmapCorrectResultAgainstOKFunction.isSuccess(), "When flatmapping a Success against a Success, we should get a Success")
+        XCTAssertEqual(flatmapCorrectResultAgainstOKFunction.getOrElse(1), 23, "When flatmapping a Success against a Success, we should get a Success of a valid value")
+        
+        let flatmapIncorrectResultAgainstOKFunction = tryParseIncorrectString.flatMap(tryHalf)
+        XCTAssertTrue(flatmapIncorrectResultAgainstOKFunction.isFailure(), "When flatmapping a Failure against a Success, we should get a Failure")
+        
+        let flatmapIncorrectResultAgainstIncorrectFunction = tryParseIncorrectString.flatMap(tryDivideByZeroWhoops)
+        XCTAssertTrue(flatmapIncorrectResultAgainstIncorrectFunction.isFailure(), "When flatmapping a Failure against a Failure, we should get a Failure")        
     }
 
 }

--- a/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
+++ b/SecondBridge/SecondBridgeTests/ErrorHandling/TryTests.swift
@@ -63,7 +63,7 @@ class TryTests: XCTestCase {
         let value = tryParseCorrectString.getOrElse(0)
         XCTAssertNotNil(value, "Correct operation inside a Try should yield a value")
         XCTAssertEqual(value, 47, "Correct operation inside a Try should yield the expected value")
-        
+                
         let tryParseIncorrectString = Try<Int>(try self.convertStringToInt("47 Degrees"))
         XCTAssertFalse(tryParseIncorrectString.isSuccess(), "Invalid operation inside a Try shouldn't be a success")
         XCTAssertTrue(tryParseIncorrectString.isFailure(), "Invalid operation inside a Try should be a failure")


### PR DESCRIPTION
This PR contains our first basic implementation of the Try monad, with the following features:

- It's based on the category theory Swiftz types, conforming to Pointed, Functor, Applicative and Monad.
- Encapsulates Swift's throwable functions, by using the new do/try blocks in Swift 2.0. Encapsulated operations are evaluated. An operation result is stored in an Success type containing its value, or in a Failure type containing the catched exception.
- It allows pattern matching to decompose it, and has utility methods like isSuccess, isFailure, getOrElse... to work with its values.
- It implements the more important HOF with the same syntax (mostly) as in Scala: map, flatMap, filter, recover, recoverWith.

- CONS: Because of the strict nature of the Swift data-type system, so far recover and recoverWith only allow to return instances of Try of the same generic type as the original instance on which the function is applied to.

This PR also includes a couple of modifications to PartialFunctions to allow some functionality to Try's recover and recoverWith functions.

Could you please review, @anamariamv? Also, it'd be nice to have your thoughts on this, @raulraja 

Thanks!